### PR TITLE
fix: updated "ActionReturn" type to be compatible with the latest version of "cds-typer"

### DIFF
--- a/lib/types/types.ts
+++ b/lib/types/types.ts
@@ -70,7 +70,7 @@ export type ActionRequest<T extends CdsFunction> = Omit<Request, 'data'> & { dat
 /**
  * Use `ActionReturn` type to have the `return` of the `@OnAction`, `@OnBoundAction`, `@OnFunction`, `@OnBoundFunction` typed.
  */
-export type ActionReturn<T extends CdsFunction> = Promise<T['__returns'] | void | Error>;
+export type ActionReturn<T extends CdsFunction> = Promise<Exclude<T['__returns'], Promise<any>> | void | Error>;
 
 // **************************************************************************************************************************
 // **************************************************************************************************************************


### PR DESCRIPTION
Latest version of `cds-typer` broke `ActionReturn` type.

The change to `__returns` type can be seen in [this PR](https://github.com/dxfrontier/cds-ts-dispatcher/pull/101/files#diff-20fbab652a34b9cf39b3461316fba08408868baf4881a3294f68857bc45a8b84R99).

Before:
```ts
export declare const sendMail: {
  (request: _.HelloRequest | null): _.HelloResponse | null;
  __parameters: { request: _.HelloRequest | null };
  __returns: _.HelloResponse | null;
  kind: "action";
};
```

After:
```ts
export declare const sendMail: {
  // positional
  (request: _.HelloRequest | null):
    | Promise<_.HelloResponse | null>
    | _.HelloResponse
    | null;
  // named
  ({ request }: { request?: _.HelloRequest | null }):
    | Promise<_.HelloResponse | null>
    | _.HelloResponse
    | null;
  // metadata (do not use)
  __parameters: { request?: _.HelloRequest | null };
  __returns: Promise<_.HelloResponse | null> | _.HelloResponse | null;
  kind: "action";
};
```

Specifically:
```
__returns: _.HelloResponse | null
```
vs:
```
__returns: Promise<_.HelloResponse | null> | _.HelloResponse | null
```
