### PR TITLE
ci(workflows): add Node 26 (Current) as a non-blocking e2e matrix leg

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,8 +92,15 @@ jobs:
       matrix:
         version: [24, 22]
         platform: [ubuntu-latest]
+        include:
+          # Node 26 is Current (Active LTS on 2026-10-28) and not yet in the runner toolcache
+          # (setup-node downloads it). Early-signal leg — flip to blocking once 26 reaches LTS.
+          - version: 26
+            platform: ubuntu-latest
 
     runs-on: ${{ matrix.platform }}
+    # the Node 26 leg must not fail the workflow while 26 is pre-LTS
+    continue-on-error: ${{ matrix.version == 26 }}
 
     steps:
       - name: Get code


### PR DESCRIPTION
## Summary

Adds Node **26** to the e2e matrix as an early-signal, non-blocking leg. Landed as a follow-up because #188 was merged while this commit was in flight.

Release landscape as of 2026-07-21 ([nodejs/Release](https://github.com/nodejs/Release), [endoflife.date](https://endoflife.date/nodejs)):

| Line | Status | Notes |
|---|---|---|
| 22 | Maintenance LTS | EOL 2027-04-30 — stays blocking (engines floor) |
| 24 | Active LTS | stays blocking |
| 26 | Current | Active LTS on **2026-10-28** — added non-blocking |
| 20 / 25 | EOL | not tested |

Implementation notes:
- Added via matrix `include` + a version-keyed `continue-on-error` instead of a new matrix axis, so the existing legs keep their exact check names (safe for branch protection).
- Node 26 is not in the hosted-runner toolcache yet; `setup-node` downloads it (a few extra seconds).
- `@sap/cds` 10 declares `engines: node >=22`, recommends 24, and anticipates 26 at its LTS date — this mirrors that posture.

Follow-up around **2026-10-28**: flip the 26 leg to blocking (drop the `continue-on-error`), per the comment in the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)