### PR TITLE
ci(workflows): publish with org-level NPM_ORG_TOKEN secret

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -58,7 +58,8 @@ jobs:
       - run: npm ci
       - run: npm run test:unit
       - run: npm run build
-      # npm provenance needs npm 9.5+ and a CI OIDC-compatible token; if the maintainer's npm_token is incompatible with provenance, drop the --provenance flag
+      # npm provenance needs npm 9.5+ and a CI OIDC-compatible token; if the org's NPM_ORG_TOKEN is incompatible with provenance, drop the --provenance flag
+      # repo-level NPM_TOKEN (classic token) was revoked in npm's Dec 2025 token purge; publishing auth lives in the org-level NPM_ORG_TOKEN granular token
       - run: npm publish --access public --provenance
         env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_ORG_TOKEN}}


### PR DESCRIPTION
## Why

Publishing 6.0.0 failed (run 29812535677) with `E404 Not Found - PUT` from the npm registry. Root cause: the workflow reads `secrets.npm_token`, which resolves to the repo-level `NPM_TOKEN` secret — a classic npm token from 2023-11 that npm revoked in its December 2025 token purge. The fresh granular token @sblessing rotated on 2026-07-20 lives in the org-level `NPM_ORG_TOKEN` secret, which the workflow never referenced.

## What

Point `NODE_AUTH_TOKEN` at `secrets.NPM_ORG_TOKEN` (plus a comment documenting why).

## Deploy

Labeled `norelease` (no new version bump — main is already at 6.0.0, unpublished) + `deploy` so merging this PR triggers the Deployment workflow with the updated secret reference and publishes 6.0.0. A rerun of the failed run would not work: reruns use the original workflow definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)